### PR TITLE
Add Apple DevOps Engineer - Agents (200631016) resume

### DIFF
--- a/docs/prospectives/apple-ai-platform.md
+++ b/docs/prospectives/apple-ai-platform.md
@@ -1,0 +1,53 @@
+---
+pdf_options:
+  margin:
+    top: 6mm
+    bottom: 6mm
+    left: 12mm
+    right: 12mm
+---
+
+### Caleb Kopp - Senior Software Engineer
+
+Saint Paul, MN &nbsp;|&nbsp; 507-299-0445 &nbsp;|&nbsp; caleb.m.kopp@outlook.com &nbsp;|&nbsp; linkedin.com/in/calebmkopp
+
+---
+
+#### Skills
+
+- **Languages:** Go, Python, Bash, TypeScript, JavaScript, Java
+- **APIs and Backend Services:** HTTP API design and development, backend service architecture, REST, micro-frontend integration, self-service provisioning APIs
+- **Deployment and DevOps:** Docker, GitHub Actions, CI/CD, Jenkins, JFrog Artifactory, HashiCorp Vault, automated deployment, container image management
+- **Infrastructure:** Kubernetes, custom operator framework development, Kubernetes CRDs, Helm, Terraform, GCP, GKE, VPC, DNS, IAM
+- **Observability:** Prometheus, Grafana, Elasticsearch, ELK, PromQL, PagerDuty, ServiceNow, Sentry, Kibana, runbooks, on-call
+- **AI and Data Science:** RAG, retrieval-augmented generation, natural language processing, sentiment analysis, machine learning, LLM API integration
+- **Security:** mTLS, PKI, certificate authority management, HashiCorp Vault, GCP KMS, IAM, PHI/PII compliance
+
+---
+
+#### Experience
+
+##### Senior Software Engineer - Optum, UnitedHealth Group
+*Sep 2022 - Present* &nbsp;|&nbsp; Saint Paul, MN
+
+- Primary technical owner of KRM, a federated network of custom Go Kubernetes operators forming a two-tier control plane managing 750+ Kafka clusters across multi-tenant GCP environments at five-nines reliability with zero customer data loss; co-author all Terraform across GKE, VPC, DNS, IAM, and CI/CD pipelines.
+- Co-led 8-week sprint taking Warpstream cluster provisioning from whiteboard to production: net-new Go operator, all Terraform from scratch (GCS, VPC, DNS, IAM), self-service API integration, full observability; shipped to two of Optum's largest GCP customers, projected to reduce annual Kafka infrastructure costs by approximately 80%.
+- Serve as lead engineer and product owner of the Kafka Clusters self-service web application (TypeScript, React, NextJS) and its HTTP API layer embedded in HCP Console; plan, develop and shape new features by collaborating with product, engineering, and stakeholder teams; captain a team of 6 engineers, write user stories, and conduct code reviews.
+- Extend the Prometheus/Grafana/Elasticsearch observability stack with Go monitoring controllers and PromQL dashboards; author runbooks and alert playbooks; troubleshoot production issues involving applications, databases, networks, and proxies; serve on-call across 1,000+ nodes.
+- Maintain the platform's certificate authority: generate, distribute, and rotate thousands of mTLS client certificates across all cloud environments; manage VPC-scoped network security and DNS for broker endpoints.
+- Own CI/CD pipeline configuration using GitHub Actions, Docker-based build pipelines, JFrog Artifactory, and HashiCorp Vault secret injection; enforce best practices for container image management and deployment automation.
+
+##### Software Engineer - Optum, UnitedHealth Group
+*Jun 2020 - Aug 2022* &nbsp;|&nbsp; Saint Paul, MN
+
+- Contributed to Go Kubernetes operator frameworks and provisioning pipelines; built a full-stack web application (React, TypeScript, Express, MSSQL) replacing spreadsheet-based inventory management, adopted by the team.
+
+---
+
+#### Certifications
+
+- Google Cloud Certified - Cloud Digital Leader (Mar 2025) &nbsp;|&nbsp; Optum AI Dojo Certificate: built a RAG system from scratch using Python (2025)
+
+#### Education
+
+B.S. Software Engineering, St. Cloud State University, GPA 3.79 &nbsp;|&nbsp; IEEE: [ieeexplore.ieee.org/document/9659615](https://ieeexplore.ieee.org/document/9659615)

--- a/docs/prospectives/apple-devops-agents.md
+++ b/docs/prospectives/apple-devops-agents.md
@@ -1,0 +1,53 @@
+---
+pdf_options:
+  margin:
+    top: 6mm
+    bottom: 6mm
+    left: 12mm
+    right: 12mm
+---
+
+### Caleb Kopp - Senior Software Engineer
+
+Saint Paul, MN &nbsp;|&nbsp; 507-299-0445 &nbsp;|&nbsp; caleb.m.kopp@outlook.com &nbsp;|&nbsp; linkedin.com/in/calebmkopp
+
+---
+
+#### Skills
+
+- **Languages:** Go, Python, Bash, TypeScript, JavaScript, Java
+- **APIs and Backend Services:** HTTP API design and development, backend service architecture, REST, micro-frontend integration, self-service provisioning APIs, API endpoint performance optimization
+- **Deployment and DevOps:** Docker, GitHub Actions, CI/CD, Jenkins, JFrog Artifactory, HashiCorp Vault, automated deployment, container image management, environment promotion workflows
+- **Observability:** Prometheus, Grafana, Elasticsearch, ELK, Kibana, PromQL, PagerDuty, ServiceNow, runbooks, on-call, production debugging
+- **Infrastructure:** Kubernetes, custom operator framework development, Kubernetes CRDs, Helm, Terraform, GCP, GKE, VPC, DNS, IAM
+- **AI:** RAG, retrieval-augmented generation, LLM API integration, natural language processing, sentiment analysis
+- **Security:** mTLS, PKI, certificate authority management, HashiCorp Vault, GCP KMS, IAM, PHI/PII compliance
+
+---
+
+#### Experience
+
+##### Senior Software Engineer - Optum, UnitedHealth Group
+*Sep 2022 - Present* &nbsp;|&nbsp; Saint Paul, MN
+
+- Serve as lead engineer and product owner of the Kafka Clusters self-service web application (TypeScript, React, NextJS) and its HTTP API layer embedded in HCP Console; plan, develop and shape new features by collaborating with product, engineering, and stakeholder teams; captain a team of 6 engineers, write user stories, conduct code reviews, and collaborate on pull requests.
+- Primary technical owner of KRM, a federated network of custom Go backend services and Kubernetes operators forming a two-tier control plane managing 750+ clusters across multi-tenant GCP environments at five-nines reliability with zero customer data loss.
+- Co-led 8-week sprint taking Warpstream cluster provisioning from whiteboard to production: net-new Go backend service, all Terraform from scratch (GCS, VPC, DNS, IAM), self-service API integration, full observability; shipped to two of Optum's largest GCP customers, projected to reduce annual infrastructure costs by approximately 80%.
+- Extend the Prometheus/Grafana/Elasticsearch observability stack with Go monitoring controllers and PromQL dashboards; support troubleshooting, mitigation and fixing of production issues involving applications, databases, networks, and proxies; author runbooks and alert playbooks; serve on-call across 1,000+ nodes.
+- Own CI/CD pipeline configuration using GitHub Actions, Docker-based build pipelines, JFrog Artifactory, and HashiCorp Vault secret injection; support and advance development environments to reduce friction when shipping to production; enforce best practices for container image management and deployment automation.
+- Maintain the platform's certificate authority: generate, distribute, and rotate thousands of mTLS client certificates; manage VPC-scoped network security and DNS for broker endpoints across all cloud environments.
+
+##### Software Engineer - Optum, UnitedHealth Group
+*Jun 2020 - Aug 2022* &nbsp;|&nbsp; Saint Paul, MN
+
+- Contributed to Go backend services and Kubernetes operator frameworks; built a full-stack web application (React, TypeScript, Express, MSSQL) replacing spreadsheet-based inventory management, adopted by the team.
+
+---
+
+#### Certifications
+
+- Google Cloud Certified - Cloud Digital Leader (Mar 2025) &nbsp;|&nbsp; Optum AI Dojo: built a RAG system from scratch using Python (2025)
+
+#### Education
+
+B.S. Software Engineering, St. Cloud State University, GPA 3.79 &nbsp;|&nbsp; IEEE: [ieeexplore.ieee.org/document/9659615](https://ieeexplore.ieee.org/document/9659615)

--- a/docs/writings/to-learn.md
+++ b/docs/writings/to-learn.md
@@ -206,5 +206,29 @@
 - AWS networking deep dive: PrivateLink for BYOC, Transit Gateway for multi-account architectures
 - Multi-account AWS patterns: AWS Organizations, SCPs, landing zones for SaaS isolation
 
+### Gaps - Apple Staff SW Engineer Applied AI (200630749) / DevOps Engineer Agents (200631016)
+
+#### LLM APIs and Applied AI
+- Building production solutions on LLM APIs: OpenAI, Anthropic, Gemini, Mistral, Llama integration patterns
+- Custom fine-tuned models: Defog, Nous Research; when to fine-tune vs prompt-engineer vs RAG
+- Prompt optimization and evaluation: systematic eval frameworks, A/B testing prompts, regression detection
+- Model pipeline and registry tools: MLflow, Weights & Biases, model versioning, artifact management
+- Model drift detection and automated monitoring: data drift vs concept drift, alerting on accuracy degradation
+- RAG at production scale beyond AI Dojo CSV project: vector DB selection (pgvector, Weaviate, Pinecone), chunking strategies, hybrid search, retrieval evaluation
+
+#### MCP Servers and AI Agent Infrastructure
+- MCP (Model Context Protocol): server implementation, tool registration, resource exposure, transport protocols (stdio, SSE, streamable HTTP)
+- MCP server deployment and scaling: containerized MCP servers, load balancing, connection management
+- Agent orchestration patterns: LangChain, LangGraph, AutoGen, CrewAI; production vs prototyping tradeoffs
+- Agent observability: tracing token flows, tool invocations, hallucination detection, evals as CI
+
+#### ETL and Data Warehousing
+- ETL pipeline construction: Snowflake, dbt, Airflow; batch vs streaming ingestion patterns
+- PostgreSQL: production experience beyond MSSQL (query optimization, indexing, EXPLAIN plans)
+- SQL at depth for analytics workloads: window functions, CTEs, materialized views
+
+#### Deployment Tooling
+- Ansible: playbook authoring, roles, inventory management, idempotent configuration (JDs list alongside Docker/Jenkins)
+
 ### Other
 - Web scraping (Selenium, etc)


### PR DESCRIPTION
## Summary
- `docs/prospectives/apple-devops-agents.md` -- focused resume for Apple DevOps Engineer - Agents (200631016): Go, HTTP APIs, Docker/CI/CD, Prometheus/Grafana/ELK, production debugging
- `docs/prospectives/apple-ai-platform.md` -- combined resume covering both 200630749 (Applied AI) and 200631016 (Agents)
- Updated `docs/writings/to-learn.md` with gaps: LLM APIs, MCP server implementation, ETL/Snowflake, PostgreSQL, Ansible

## Gap analysis
- **Strong matches:** Go (preferred language), full-stack web + HTTP APIs, Docker/CI/CD/deployment automation, Prometheus/Grafana/ELK (explicitly in JD), production troubleshooting, code reviews, cross-functional collaboration
- **Honest gaps:** YOE (8+ required, 6 total), MCP server implementation, LLM API integration at production depth, Ansible, PostgreSQL, ETL/Snowflake
- **Overall:** Stretch on YOE, but recruiter reached out directly. 200631016 (Agents) is the stronger fit -- platform infra for AI agents vs ML engineering

https://claude.ai/code/session_014meX6ucUAxxGqmhexYhLuF

---
_Generated by [Claude Code](https://claude.ai/code/session_014meX6ucUAxxGqmhexYhLuF)_