### PR TITLE
Add Optum KT outline and goodbye email draft

### DIFF
--- a/docs/writings/optum-goodbye-email.md
+++ b/docs/writings/optum-goodbye-email.md
@@ -1,0 +1,19 @@
+# Goodbye Email Draft
+
+Subject: Moving On - Thank You
+
+Draft notes - bullet points to expand/personalize before sending.
+
+- Announce that I'm leaving Optum/UHG for a new opportunity at Oracle, with effective date / last day
+- Open with genuine gratitude - this has been one of the most rewarding chapters of my career
+- Reflect on the journey: started as an SE, grew into a Senior role, became a primary owner of the KaaS platform
+- Call out the privilege of building KRM/PRM and the self-service portal from the ground up alongside the team
+- Highlight the Warpstream sprint as a standout memory - a true team effort delivered against a tight timeline
+- Thank the team for their trust, collaboration, and the day-to-day camaraderie (on-call, war rooms, code reviews)
+- Acknowledge leadership/manager for the mentorship and opportunities to grow (Early Careers, captaining the team, GCP certification)
+- Express pride in what the team built together and confidence it will continue to thrive
+- Note it's been an honor to support a mission tied to healthcare - knowing the work matters
+- Offer to help with the knowledge transfer / answer questions during the transition
+- Share personal contact info (LinkedIn / personal email) for staying in touch
+- Close with warm wishes for the team's continued success and a thank-you for the memories
+- Sign-off

--- a/docs/writings/optum-kt-outline.md
+++ b/docs/writings/optum-kt-outline.md
@@ -1,0 +1,82 @@
+# Knowledge Transfer Outline - Kafka-as-a-Service Platform
+
+Outline only. To be filled in by Caleb before handoff.
+
+## 1. Platform Overview
+- High-level architecture summary
+- Scale stats (nodes, clusters, environments)
+- Open-source Apache Kafka vs. Confluent licensed components (Schema Registry, Warpstream)
+
+## 2. KRM (Kubernetes Resource Manager)
+- Two-tier control plane architecture
+- Repo locations and code structure
+- Key CRDs and reconciliation loops
+- Deployment/upgrade process
+- Known edge cases and gotchas
+
+## 3. PRM (Platform Resource Manager)
+- Provisioning framework overview
+- How it integrates with KRM and the self-service portal
+- Repo locations and code structure
+- Known edge cases and gotchas
+
+## 4. Warpstream Operator and Infrastructure
+- Operator architecture and repo location
+- Terraform modules (GCS, VPC, DNS, IAM)
+- Current rollout status (beta customers, next steps)
+- Confluent licensing/coordination notes
+
+## 5. Schema Registry (Self-Hosted)
+- Helm chart location and structure
+- Certificate/ACL setup
+- Upgrade and maintenance process
+
+## 6. Self-Service Developer Portal
+- Frontend repo structure (TypeScript/React/NextJS)
+- API layer / provisioning pipeline
+- HCP Console integration points
+- Current roadmap items / in-flight features
+
+## 7. CI/CD Pipelines
+- GitHub Actions workflows overview
+- Docker build pipeline and JFrog Artifactory
+- HashiCorp Vault secret injection setup
+- Environment promotion process
+
+## 8. Certificate Authority / mTLS
+- CA structure and location
+- Certificate generation, distribution, and rotation process
+- Rotation schedule and upcoming renewals
+- VPC/DNS configuration for broker endpoints
+
+## 9. Observability Stack
+- Prometheus/Grafana/Elasticsearch architecture
+- Custom Go monitoring controllers
+- Key dashboards and PromQL queries
+- Runbook and alert playbook locations
+
+## 10. On-Call
+- On-call rotation and escalation process
+- Common incident types and mitigation steps
+- War room procedures
+- Links to existing runbooks
+
+## 11. Open Initiatives and In-Flight Work
+- Active projects and their status
+- Upcoming deadlines/commitments
+- Stakeholders to keep informed
+
+## 12. Risks, Tech Debt, and Outstanding TODOs
+- Known issues and workarounds
+- Areas needing refactor or cleanup
+- Single points of knowledge (things only I know)
+
+## 13. Key Contacts
+- Team members and their areas of ownership
+- Cross-team stakeholders (product, security, compliance, central portal team)
+- External vendor contacts (Confluent)
+
+## 14. Team and Mentorship
+- Current team structure and responsibilities
+- Early Careers / mentee status
+- Code review and onboarding norms


### PR DESCRIPTION
Adds two new docs under `docs/writings/` for the Optum -> Oracle transition:

- `optum-kt-outline.md`: section headers/outline only for the knowledge transfer doc (to be filled in by Caleb)
- `optum-goodbye-email.md`: bullet-point draft for a farewell email expressing gratitude for the team and time at Optum

---
_Generated by [Claude Code](https://claude.ai/code/session_014meX6ucUAxxGqmhexYhLuF)_